### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,4 @@ workshoppers without installing them globally.
 - learnyoucouchdb
 - learn-generators
 - learnyoureact
-- perfschoo
+- perfschool


### PR DESCRIPTION
Hey, just stumbled across this repo and noticed what seems to be a typo in the README (perfschoo => perfschool). Here is a quick patch fixing that.

Thanks for making this and for making it available.

Have a good weekend!
